### PR TITLE
return 400 for request with non-empty blank lat or lon url param

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,17 +9,23 @@ const morgan = require( 'morgan' );
 const logger = require('pelias-logger').get('pip');
 const through = require( 'through2' );
 
-const validate = (req, res, next) => {
-  req.query.centroid = {
-    lat: _.toNumber(req.params.lat),
-    lon: _.toNumber(req.params.lon)
-  };
+function isFiniteNumber(value) {
+  return !_.isEmpty(_.trim(value)) && _.isFinite(_.toNumber(value));
+}
 
-  if (!_.isFinite(req.query.centroid.lat) || !_.isFinite(req.query.centroid.lon)) {
+const validate = (req, res, next) => {
+  if (_.at(req.params, ['lat', 'lon']).every(isFiniteNumber)) {
+    // both lat and lon are non-blank finite numbers, so validation step passes
+    req.query.centroid = {
+      lat: _.toNumber(req.params.lat),
+      lon: _.toNumber(req.params.lon)
+    };
+    next();
+
+  } else {
     res.status(400).send('Cannot parse input');
     next('route'); // skip lookup middleware and output, still logs
-  } else {
-    next();
+
   }
 
 };

--- a/test/app.js
+++ b/test/app.js
@@ -7,7 +7,7 @@ const temp = require('temp').track();
 const mocklogger = require('pelias-mock-logger');
 
 tape('entry point tests', (test) => {
-  test.test('valid lat/lon should call lookup and return result', (t) => {
+  test.test('finite/non-blank lat/lon should call lookup and return result', (t) => {
     const logger = mocklogger();
 
     temp.mkdir('whosonfirst', (err, temp_dir) => {
@@ -88,10 +88,10 @@ tape('entry point tests', (test) => {
 
   });
 
-  ['a', NaN, Infinity, '{}', false, null, undefined].forEach((bad_lat_value) => {
-    const logger = mocklogger();
+  test.test('non-blank/finite lat should return 400', (t) => {
+    ['a', NaN, Infinity, '{}', false, null, undefined, ' '].forEach((bad_lat_value) => {
+      const logger = mocklogger();
 
-    test.test('non-finite lat should return 400', (t) => {
       temp.mkdir('whosonfirst', (err, temp_dir) => {
         t.notOk(err);
 
@@ -111,15 +111,15 @@ tape('entry point tests', (test) => {
           },
           'pelias-logger': logger
         })(temp_dir);
+
         const server = app.listen();
         const port = server.address().port;
 
-        request.get(`http://localhost:${port}/21.212121/${bad_lat_value}`, (err, response, body) => {
+        request.get(encodeURI(`http://localhost:${port}/21.212121/${bad_lat_value}`), (err, response, body) => {
           t.ok(logger.hasInfoMessages());
           t.notOk(err);
           t.equals(response.statusCode, 400);
           t.equals(body, 'Cannot parse input');
-          t.end();
           server.close();
           temp.cleanupSync();
 
@@ -128,13 +128,15 @@ tape('entry point tests', (test) => {
       });
 
     });
+
+    t.end();
 
   });
 
-  ['a', NaN, Infinity, '{}', false, null, undefined].forEach((bad_lon_value) => {
-    const logger = mocklogger();
+  test.test('non-blank/finite lon should return 400', (t) => {
+    ['a', NaN, Infinity, '{}', false, null, undefined, ' '].forEach((bad_lon_value) => {
+      const logger = mocklogger();
 
-    test.test('non-finite lon should return 400', (t) => {
       temp.mkdir('whosonfirst', (err, temp_dir) => {
         t.notOk(err);
 
@@ -154,15 +156,15 @@ tape('entry point tests', (test) => {
           },
           'pelias-logger': logger
         })(temp_dir);
+
         const server = app.listen();
         const port = server.address().port;
 
-        request.get(`http://localhost:${port}/${bad_lon_value}/12.121212`, (err, response, body) => {
+        request.get(encodeURI(`http://localhost:${port}/${bad_lon_value}/21.212121`), (err, response, body) => {
           t.ok(logger.hasInfoMessages());
           t.notOk(err);
           t.equals(response.statusCode, 400);
           t.equals(body, 'Cannot parse input');
-          t.end();
           server.close();
           temp.cleanupSync();
 
@@ -171,6 +173,8 @@ tape('entry point tests', (test) => {
       });
 
     });
+
+    t.end();
 
   });
 


### PR DESCRIPTION
`_.toNumber` converts ` ` to `0` which causes bad behavior

This was allowing `http://localhost:3102/%20/12.121212` to be interpreted as lon `0` and lat `12.121212`.