### PR TITLE
Increase Node.js memory limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0-development",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
+    "start": "node --max_old_space_size=4096 index.js",
     "test": "node test/test | tap-dot",
     "lint": "jshint .",
     "travis": "npm run check-dependencies && npm test",


### PR DESCRIPTION
The amount of data in WOF is reaching the point where some workers are
hitting the default Node.js memory limit and crashing. Increasing the
Node.js limit doesn't fix the problem, but gives us time to come up with
a new architecture that does.

Connected to https://github.com/pelias/wof-admin-lookup/issues/117