### PR TITLE
Node module installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This service provides Who's on First-based point-in-polygon lookup functionality
 ## Installation
 
 ```bash
-git clone git@github.com:pelias/pip-service.git
-cd pip-service
-npm install
+$ git clone git@github.com:pelias/pip-service.git
+$ cd pip-service
+$ npm install
 ```
 
 [![NPM](https://nodei.co/npm/pelias-pip-service.png?downloads=true&stars=true)](https://nodei.co/npm/pelias-pip-service)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This service provides Who's on First-based point-in-polygon lookup functionality
 ## Installation
 
 ```bash
-$ npm install pelias-pip-service
+git clone git@github.com:pelias/pip-service.git
+cd pip-service
+npm install
 ```
 
 [![NPM](https://nodei.co/npm/pelias-pip-service.png?downloads=true&stars=true)](https://nodei.co/npm/pelias-pip-service)


### PR DESCRIPTION
PIP Service needs to have its node modules installed before it can run `npm start <path to Who's on First data>`.

"Installation" section said `npm install pelias-pip-service` which is for installing the node module pelias-pip-service into another repo that requires pelias-pip-service as a dependency. The "NPM Module" section covers that step.