### PR TITLE
bumped pelias-wof-admin-lookup version to 3.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash": "^4.17.4",
     "morgan": "^1.8.1",
     "pelias-logger": "^0.2.0",
-    "pelias-wof-admin-lookup": "^3.8.0",
+    "pelias-wof-admin-lookup": "^3.10.0",
     "through2": "^2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
3.8.0 -> 3.10.0

greenkeeper is disabled so bumping manually