### PR TITLE
Explicitly close HTTP server to avoid process.exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
+const app = require('./app')();
+
 try {
-  const app = require('./app')();
   const port = ( parseInt(process.env.PORT) || 3102 );
 
   app.listen(port, () => {
@@ -8,6 +9,8 @@ try {
 
 } catch (err) {
   console.error(err);
-  process.exit(1);
 
+  // use exitCode to exit safely: https://nodejs.org/api/process.html#process_process_exit_code
+  process.exitCode = 1;
+  app.close();
 }


### PR DESCRIPTION
Using `process.exit` directly can cause output to stderr/stdout to be truncated, since it [does not wait for output to streams to be sent](https://nodejs.org/api/process.html#process_process_exit_code).

This probably isn't an issue here for the PIP service, but it's worth avoiding it since explicitly closing the HTTP server created by express is easy, and will cause the process to quit "naturally", as nothing else
is running.

We did actually run into this issue in the [fuzzy-tester](https://github.com/pelias/fuzzy-tester/pull/44) and it's a pain to track down.