### PR TITLE
Add Node.js 8 to Travis Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ notifications:
 node_js:
   - 4
   - 6
+  - 8
 matrix:
   fast_finish: true
 env:


### PR DESCRIPTION
Now that https://github.com/pelias/pip-service/pull/46 has been merged, the PIP service also supports Node.js 8. In testing, Node 8 appears to come with a significant speed boost.

Using `benchmark.js` we see what could be up to a 40% increase in performance.

Node.js 6:
```
local PIP x 996 ops/sec ±10.99% (70 runs sampled)
```

Node.js 8:
```
local PIP x 1,432 ops/sec ±3.04% (76 runs sampled)
```

These tests use only a single concurrent request, so real world performance is higher, but the percentage change is what's most important.

Connects https://github.com/pelias/pelias/issues/612