### PR TITLE
Use localResolver method from pelias-wof-admin-lookup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN npm install
 RUN npm test
 
 # start the pip service using the directory the data was downloaded to
-CMD ["npm", "start", "--", "/data/whosonfirst"]
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The `pelias-pip-service` npm module can be found here:
 
 #### Usage
 
-To start the PiP service, type: `npm start <path to Who's on First data>`.  By default, the service starts on port 3102.  
+To start the PiP service, type: `npm start`.  By default, the service starts on port 3102. It will look for Who's on First data in the place configured in `pelias.json`.
 
 Requests are made to the endpoint in the format:  `http://localhost:3102/<lon>/<lat>`.
 
@@ -42,6 +42,7 @@ Because [pelias/whosonfirst](https://github.com/pelias/whosonfirst) is a depende
 `npm run download`
 
 This will download Who's on First data using the same [configuration options](https://github.com/pelias/whosonfirst#downloading-the-data) from `pelias.json` as the whosonfirst downloader.
+That means it will automatically put the data in the place the service will expect to load it from.
 
 ##### Privacy Concerns
 
@@ -57,4 +58,4 @@ When any of these headers are supplied in the request (with any value), the requ
 
 The only available configuration option is the port on which the service runs.  To run on a different port, start with:
 
-`PORT=3103 npm start <path to Who's on First data>`
+`PORT=3103 npm start`

--- a/app.js
+++ b/app.js
@@ -97,7 +97,7 @@ module.exports = (datapath) => {
     throw Error(`${datapath} does not contain Who's on First data`);
   }
 
-  const pointInPoly = adminLookup.resolver(datapath);
+  const pointInPoly = adminLookup.localResolver();
 
   const router = new Router();
   router.get('/:lon/:lat', validate, parseLayers, lookup(pointInPoly), output);

--- a/app.js
+++ b/app.js
@@ -91,12 +91,7 @@ function log() {
   });
 }
 
-module.exports = (datapath) => {
-  // verify the WOF data structure first (must contain data and meta directories)
-  if (!['meta', 'data'].every((sub) => { return fs.existsSync(path.join(datapath, sub)); })) {
-    throw Error(`${datapath} does not contain Who's on First data`);
-  }
-
+module.exports = () => {
   const pointInPoly = adminLookup.localResolver();
 
   const router = new Router();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 try {
-  const app = require('./app')(process.argv[2]);
+  const app = require('./app')();
   const port = ( parseInt(process.env.PORT) || 3102 );
 
   app.listen(port, () => {

--- a/test/app.js
+++ b/test/app.js
@@ -18,8 +18,7 @@ tape('entry point tests', (test) => {
 
       const app = proxyquire('../app', {
         'pelias-wof-admin-lookup': {
-          resolver: (datapath) => {
-            t.equals(datapath, temp_dir);
+          localResolver: () => {
             return {
               lookup: (centroid, layers, callback) => {
                 t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
@@ -60,8 +59,7 @@ tape('entry point tests', (test) => {
 
       const app = proxyquire('../app', {
         'pelias-wof-admin-lookup': {
-          resolver: (datapath) => {
-            t.equals(datapath, temp_dir);
+          localResolver: () => {
             return {
               lookup: (centroid, layers, callback) => {
                 t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
@@ -102,8 +100,7 @@ tape('entry point tests', (test) => {
 
       const app = proxyquire('../app', {
         'pelias-wof-admin-lookup': {
-          resolver: (datapath) => {
-            t.equals(datapath, temp_dir);
+          localResolver: () => {
             return {
               lookup: (centroid, layers, callback) => {
                 t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
@@ -144,8 +141,7 @@ tape('entry point tests', (test) => {
 
       const app = proxyquire('../app', {
         'pelias-wof-admin-lookup': {
-          resolver: (datapath) => {
-            t.equals(datapath, temp_dir);
+          localResolver: () => {
             return {
               lookup: (centroid, layers, callback) => {
                 t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
@@ -186,8 +182,7 @@ tape('entry point tests', (test) => {
 
       const app = proxyquire('../app', {
         'pelias-wof-admin-lookup': {
-          resolver: (datapath) => {
-            t.equals(datapath, temp_dir);
+          localResolver: () => {
             return {
               lookup: () => {
                 throw Error('lookup should not have been called');
@@ -226,8 +221,7 @@ tape('entry point tests', (test) => {
 
         const app = proxyquire('../app', {
           'pelias-wof-admin-lookup': {
-            resolver: (datapath) => {
-              t.equals(datapath, temp_dir);
+            localResolver: () => {
               return {
                 lookup: () => {
                   throw Error('lookup should not have been called');
@@ -271,8 +265,7 @@ tape('entry point tests', (test) => {
 
         const app = proxyquire('../app', {
           'pelias-wof-admin-lookup': {
-            resolver: (datapath) => {
-              t.equals(datapath, temp_dir);
+            localResolver: () => {
               return {
                 lookup: () => {
                   throw Error('lookup should not have been called');
@@ -376,8 +369,7 @@ tape('entry point tests', (test) => {
 
         const app = proxyquire('../app', {
           'pelias-wof-admin-lookup': {
-            resolver: (datapath) => {
-              t.equals(datapath, temp_dir);
+            localResolver: () => {
               return {
                 lookup: (centroid, layers, callback) => {
                   t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });

--- a/test/app.js
+++ b/test/app.js
@@ -3,182 +3,155 @@ const request = require('request');
 const proxyquire = require('proxyquire').noCallThru();
 const fs = require('fs');
 const path = require('path');
-const temp = require('temp').track();
 const mocklogger = require('pelias-mock-logger');
 
 tape('entry point tests', (test) => {
   test.test('finite/non-blank lat/lon should call lookup and return result', (t) => {
     const logger = mocklogger();
+    const app = proxyquire('../app', {
+      'pelias-wof-admin-lookup': {
+        localResolver: () => {
+          return {
+            lookup: (centroid, layers, callback) => {
+              t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
+              t.deepEquals(layers, undefined);
+              callback(undefined, 'this is the result');
+            }
+          };
+        }
+      },
+      'pelias-logger': logger
+    })();
+    const server = app.listen();
+    const port = server.address().port;
 
-    temp.mkdir('whosonfirst', (err, temp_dir) => {
+    request.get(`http://localhost:${port}/21.212121/12.121212`, (err, response, body) => {
+      t.ok(logger.isInfoMessage(/GET \/21.212121\/12.121212 /));
       t.notOk(err);
-
-      fs.mkdirSync(path.join(temp_dir, 'data'));
-      fs.mkdirSync(path.join(temp_dir, 'meta'));
-
-      const app = proxyquire('../app', {
-        'pelias-wof-admin-lookup': {
-          localResolver: () => {
-            return {
-              lookup: (centroid, layers, callback) => {
-                t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
-                t.deepEquals(layers, undefined);
-                callback(undefined, 'this is the result');
-              }
-            };
-          }
-        },
-        'pelias-logger': logger
-      })(temp_dir);
-      const server = app.listen();
-      const port = server.address().port;
-
-      request.get(`http://localhost:${port}/21.212121/12.121212`, (err, response, body) => {
-        t.ok(logger.isInfoMessage(/GET \/21.212121\/12.121212 /));
-        t.notOk(err);
-        t.equals(response.statusCode, 200);
-        t.equals(body, 'this is the result');
-        t.end();
-        server.close();
-        temp.cleanupSync();
-
-      });
-
+      t.equals(response.statusCode, 200);
+      t.equals(body, 'this is the result');
+      t.end();
+      server.close();
     });
-
   });
 
   test.test('layers should be passed to lookup when supplied', t => {
     const logger = mocklogger();
 
-    temp.mkdir('whosonfirst', (err, temp_dir) => {
+    const app = proxyquire('../app', {
+      'pelias-wof-admin-lookup': {
+        localResolver: () => {
+          return {
+            lookup: (centroid, layers, callback) => {
+              t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
+              t.deepEquals(layers, ['layer1', 'layer2']);
+              callback(undefined, 'this is the result');
+            }
+          };
+        }
+      },
+      'pelias-logger': logger
+    })();
+    const server = app.listen();
+    const port = server.address().port;
+
+    request.get(`http://localhost:${port}/21.212121/12.121212?layers=%20layer1%20,,%20layer2%20`, (err, response, body) => {
+      t.ok(logger.isInfoMessage(/GET \/21.212121\/12.121212\?layers=%20layer1%20,,%20layer2%20 /));
       t.notOk(err);
-
-      fs.mkdirSync(path.join(temp_dir, 'data'));
-      fs.mkdirSync(path.join(temp_dir, 'meta'));
-
-      const app = proxyquire('../app', {
-        'pelias-wof-admin-lookup': {
-          localResolver: () => {
-            return {
-              lookup: (centroid, layers, callback) => {
-                t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
-                t.deepEquals(layers, ['layer1', 'layer2']);
-                callback(undefined, 'this is the result');
-              }
-            };
-          }
-        },
-        'pelias-logger': logger
-      })(temp_dir);
-      const server = app.listen();
-      const port = server.address().port;
-
-      request.get(`http://localhost:${port}/21.212121/12.121212?layers=%20layer1%20,,%20layer2%20`, (err, response, body) => {
-        t.ok(logger.isInfoMessage(/GET \/21.212121\/12.121212\?layers=%20layer1%20,,%20layer2%20 /));
-        t.notOk(err);
-        t.equals(response.statusCode, 200);
-        t.equals(body, 'this is the result');
-        t.end();
-        server.close();
-        temp.cleanupSync();
-
-      });
-
+      t.equals(response.statusCode, 200);
+      t.equals(body, 'this is the result');
+      t.end();
+      server.close();
     });
-
   });
 
   test.test('layers trimmable to empty string should pass undefined to lookup', t => {
     const logger = mocklogger();
+    const app = proxyquire('../app', {
+      'pelias-wof-admin-lookup': {
+        localResolver: () => {
+          return {
+            lookup: (centroid, layers, callback) => {
+              t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
+              t.deepEquals(layers, undefined);
+              callback(undefined, 'this is the result');
+            }
+          };
+        }
+      },
+      'pelias-logger': logger
+    })();
+    const server = app.listen();
+    const port = server.address().port;
 
-    temp.mkdir('whosonfirst', (err, temp_dir) => {
+    request.get(`http://localhost:${port}/21.212121/12.121212?layers=%20`, (err, response, body) => {
+      t.ok(logger.isInfoMessage(/GET \/21.212121\/12.121212\?layers=%20 /));
       t.notOk(err);
-
-      fs.mkdirSync(path.join(temp_dir, 'data'));
-      fs.mkdirSync(path.join(temp_dir, 'meta'));
-
-      const app = proxyquire('../app', {
-        'pelias-wof-admin-lookup': {
-          localResolver: () => {
-            return {
-              lookup: (centroid, layers, callback) => {
-                t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
-                t.deepEquals(layers, undefined);
-                callback(undefined, 'this is the result');
-              }
-            };
-          }
-        },
-        'pelias-logger': logger
-      })(temp_dir);
-      const server = app.listen();
-      const port = server.address().port;
-
-      request.get(`http://localhost:${port}/21.212121/12.121212?layers=%20`, (err, response, body) => {
-        t.ok(logger.isInfoMessage(/GET \/21.212121\/12.121212\?layers=%20 /));
-        t.notOk(err);
-        t.equals(response.statusCode, 200);
-        t.equals(body, 'this is the result');
-        t.end();
-        server.close();
-        temp.cleanupSync();
-
-      });
-
+      t.equals(response.statusCode, 200);
+      t.equals(body, 'this is the result');
+      t.end();
+      server.close();
     });
-
   });
 
   test.test('layers reduceable to all empty strings should pass undefined to lookup', t => {
     const logger = mocklogger();
+    const app = proxyquire('../app', {
+      'pelias-wof-admin-lookup': {
+        localResolver: () => {
+          return {
+            lookup: (centroid, layers, callback) => {
+              t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
+              t.deepEquals(layers, undefined);
+              callback(undefined, 'this is the result');
+            }
+          };
+        }
+      },
+      'pelias-logger': logger
+    })();
+    const server = app.listen();
+    const port = server.address().port;
 
-    temp.mkdir('whosonfirst', (err, temp_dir) => {
+    request.get(`http://localhost:${port}/21.212121/12.121212?layers=,,`, (err, response, body) => {
+      t.ok(logger.isInfoMessage(/GET \/21.212121\/12.121212\?layers=,, /));
       t.notOk(err);
-
-      fs.mkdirSync(path.join(temp_dir, 'data'));
-      fs.mkdirSync(path.join(temp_dir, 'meta'));
-
-      const app = proxyquire('../app', {
-        'pelias-wof-admin-lookup': {
-          localResolver: () => {
-            return {
-              lookup: (centroid, layers, callback) => {
-                t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
-                t.deepEquals(layers, undefined);
-                callback(undefined, 'this is the result');
-              }
-            };
-          }
-        },
-        'pelias-logger': logger
-      })(temp_dir);
-      const server = app.listen();
-      const port = server.address().port;
-
-      request.get(`http://localhost:${port}/21.212121/12.121212?layers=,,`, (err, response, body) => {
-        t.ok(logger.isInfoMessage(/GET \/21.212121\/12.121212\?layers=,, /));
-        t.notOk(err);
-        t.equals(response.statusCode, 200);
-        t.equals(body, 'this is the result');
-        t.end();
-        server.close();
-        temp.cleanupSync();
-
-      });
-
+      t.equals(response.statusCode, 200);
+      t.equals(body, 'this is the result');
+      t.end();
+      server.close();
     });
-
   });
 
   test.test('request not matching desired path should return 404', (t) => {
     const logger = mocklogger();
+    const app = proxyquire('../app', {
+      'pelias-wof-admin-lookup': {
+        localResolver: () => {
+          return {
+            lookup: () => {
+              throw Error('lookup should not have been called');
+            }
+          };
+        }
+      },
+      'pelias-logger': logger
+    })();
+    const server = app.listen();
+    const port = server.address().port;
 
-    temp.mkdir('whosonfirst', (err, temp_dir) => {
+    request.get(`http://localhost:${port}/21.212121`, (err, response, body) => {
+      t.ok(logger.hasInfoMessages());
       t.notOk(err);
+      t.equals(response.statusCode, 404);
+      t.end();
+      server.close();
+    });
+  });
 
-      fs.mkdirSync(path.join(temp_dir, 'data'));
-      fs.mkdirSync(path.join(temp_dir, 'meta'));
+  test.test('non-blank/finite lat should return 400', (t) => {
+    ['a', NaN, Infinity, '{}', false, null, undefined, ' '].forEach((bad_lat_value) => {
+      const logger = mocklogger();
 
       const app = proxyquire('../app', {
         'pelias-wof-admin-lookup': {
@@ -191,223 +164,89 @@ tape('entry point tests', (test) => {
           }
         },
         'pelias-logger': logger
-      })(temp_dir);
+      })();
+
       const server = app.listen();
       const port = server.address().port;
 
-      request.get(`http://localhost:${port}/21.212121`, (err, response, body) => {
+      request.get(encodeURI(`http://localhost:${port}/21.212121/${bad_lat_value}`), (err, response, body) => {
         t.ok(logger.hasInfoMessages());
         t.notOk(err);
-        t.equals(response.statusCode, 404);
-        t.end();
+        t.equals(response.statusCode, 400);
+        t.equals(body, 'Cannot parse input');
         server.close();
-        temp.cleanupSync();
-
       });
-
     });
-
-  });
-
-  test.test('non-blank/finite lat should return 400', (t) => {
-    ['a', NaN, Infinity, '{}', false, null, undefined, ' '].forEach((bad_lat_value) => {
-      const logger = mocklogger();
-
-      temp.mkdir('whosonfirst', (err, temp_dir) => {
-        t.notOk(err);
-
-        fs.mkdirSync(path.join(temp_dir, 'data'));
-        fs.mkdirSync(path.join(temp_dir, 'meta'));
-
-        const app = proxyquire('../app', {
-          'pelias-wof-admin-lookup': {
-            localResolver: () => {
-              return {
-                lookup: () => {
-                  throw Error('lookup should not have been called');
-                }
-              };
-            }
-          },
-          'pelias-logger': logger
-        })(temp_dir);
-
-        const server = app.listen();
-        const port = server.address().port;
-
-        request.get(encodeURI(`http://localhost:${port}/21.212121/${bad_lat_value}`), (err, response, body) => {
-          t.ok(logger.hasInfoMessages());
-          t.notOk(err);
-          t.equals(response.statusCode, 400);
-          t.equals(body, 'Cannot parse input');
-          server.close();
-          temp.cleanupSync();
-
-        });
-
-      });
-
-    });
-
     t.end();
-
   });
 
   test.test('non-blank/finite lon should return 400', (t) => {
     ['a', NaN, Infinity, '{}', false, null, undefined, ' '].forEach((bad_lon_value) => {
       const logger = mocklogger();
-
-      temp.mkdir('whosonfirst', (err, temp_dir) => {
-        t.notOk(err);
-
-        fs.mkdirSync(path.join(temp_dir, 'data'));
-        fs.mkdirSync(path.join(temp_dir, 'meta'));
-
-        const app = proxyquire('../app', {
-          'pelias-wof-admin-lookup': {
-            localResolver: () => {
-              return {
-                lookup: () => {
-                  throw Error('lookup should not have been called');
-                }
-              };
-            }
-          },
-          'pelias-logger': logger
-        })(temp_dir);
-
-        const server = app.listen();
-        const port = server.address().port;
-
-        request.get(encodeURI(`http://localhost:${port}/${bad_lon_value}/21.212121`), (err, response, body) => {
-          t.ok(logger.hasInfoMessages());
-          t.notOk(err);
-          t.equals(response.statusCode, 400);
-          t.equals(body, 'Cannot parse input');
-          server.close();
-          temp.cleanupSync();
-
-        });
-
-      });
-
-    });
-
-    t.end();
-
-  });
-
-  test.test('non-existent whosonfirst directory should throw error', (t) => {
-    t.throws(() => {
-      proxyquire('../app', {
+      const app = proxyquire('../app', {
         'pelias-wof-admin-lookup': {
-          resolver: (datapath) => {
-            throw Error('resolver() should not have been called');
+          localResolver: () => {
+            return {
+              lookup: () => {
+                throw Error('lookup should not have been called');
+              }
+            };
           }
-        }
-      })('directory_that_does_not_exist');
+        },
+        'pelias-logger': logger
+      })();
 
-    }, /directory_that_does_not_exist does not contain Who's on First data/);
+      const server = app.listen();
+      const port = server.address().port;
 
+      request.get(encodeURI(`http://localhost:${port}/${bad_lon_value}/21.212121`), (err, response, body) => {
+        t.ok(logger.hasInfoMessages());
+        t.notOk(err);
+        t.equals(response.statusCode, 400);
+        t.equals(body, 'Cannot parse input');
+        server.close();
+      });
+    });
     t.end();
-
-  });
-
-  test.test('non-existent whosonfirst/data directory should throw error', (t) => {
-    temp.mkdir('whosonfirst', (err, temp_dir) => {
-      t.throws(() => {
-        fs.mkdirSync(path.join(temp_dir, 'meta'));
-
-        const app = proxyquire('../app', {
-          'pelias-wof-admin-lookup': {
-            resolver: (datapath) => {
-              throw Error('resolver() should not have been called');
-            }
-          }
-        })(temp_dir);
-
-      }, new RegExp(`${temp_dir} does not contain Who's on First data`));
-
-      t.end();
-      temp.cleanupSync();
-
-    });
-
-  });
-
-  test.test('non-existent whosonfirst/meta directory should throw error', (t) => {
-    temp.mkdir('whosonfirst', (err, temp_dir) => {
-      t.throws(() => {
-        fs.mkdirSync(path.join(temp_dir, 'data'));
-
-        const app = proxyquire('../app', {
-          'pelias-wof-admin-lookup': {
-            resolver: (datapath) => {
-              throw Error('resolver() should not have been called');
-            }
-          }
-        })(temp_dir);
-
-      }, new RegExp(`${temp_dir} does not contain Who's on First data`));
-
-      t.end();
-      temp.cleanupSync();
-
-    });
-
   });
 
   test.test('presence of any do_not_track header should log request without lat/lon', (t) => {
     ['DNT', 'dnt', 'do_not_track'].forEach((header) => {
       const logger = mocklogger();
 
-      temp.mkdir('whosonfirst', (err, temp_dir) => {
-        t.notOk(err);
-
-        fs.mkdirSync(path.join(temp_dir, 'data'));
-        fs.mkdirSync(path.join(temp_dir, 'meta'));
-
-        const app = proxyquire('../app', {
-          'pelias-wof-admin-lookup': {
-            localResolver: () => {
-              return {
-                lookup: (centroid, layers, callback) => {
-                  t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
-                  t.deepEquals(layers, undefined);
-                  callback(undefined, 'this is the result');
-                }
-              };
-            }
-          },
-          'pelias-logger': logger
-        })(temp_dir);
-        const server = app.listen();
-        const port = server.address().port;
-
-        const options = {
-          url: `http://localhost:${port}/21.212121/12.121212`,
-          headers: {}
-        };
-
-        options.headers[header] = `${header} header value`;
-
-        request(options, (err, response, body) => {
-            t.ok(logger.isInfoMessage(/GET \/\[removed\]\/\[removed\] /));
-            t.notOk(err);
-            t.equals(response.statusCode, 200);
-            t.equals(body, 'this is the result');
-
-            server.close();
-            temp.cleanupSync();
+      const app = proxyquire('../app', {
+        'pelias-wof-admin-lookup': {
+          localResolver: () => {
+            return {
+              lookup: (centroid, layers, callback) => {
+                t.deepEquals(centroid, { lat: 12.121212, lon: 21.212121 });
+                t.deepEquals(layers, undefined);
+                callback(undefined, 'this is the result');
+              }
+            };
           }
-        );
+        },
+        'pelias-logger': logger
+      })();
+      const server = app.listen();
+      const port = server.address().port;
 
+      const options = {
+        url: `http://localhost:${port}/21.212121/12.121212`,
+        headers: {}
+      };
+
+      options.headers[header] = `${header} header value`;
+
+      request(options, (err, response, body) => {
+        t.ok(logger.isInfoMessage(/GET \/\[removed\]\/\[removed\] /));
+        t.notOk(err);
+        t.equals(response.statusCode, 200);
+        t.equals(body, 'this is the result');
+
+        server.close();
       });
-
     });
-
     t.end();
-
   });
-
 });


### PR DESCRIPTION
This fixes the issue where the pip-service will recursively call itself if the `pelias.json` configuration is telling `pelias-wof-admin-lookup` to try to connect to a remote pip-service when doing any PIP requests. The pip-service is always used to actually serve those requests, so it should never look elsewhere (and definitely not to itself recursively!).

This also means that pelias-wof-admin-lookup is now the source of truth for where to load the whosonfirst data from. Therefore it doesn't need to be configured in the PIP service via the startup parameter. The tests are a lot shorter and run a lot faster! It also guarantees that the WOF downloader and the pip-service will coordinate together, since they ultimately both pull the directory of WOF data from the same `pelias.json` config option.