### PR TITLE
Add script to start service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN npm install
 RUN npm test
 
 # start the pip service using the directory the data was downloaded to
-CMD ["npm", "start"]
+CMD ["./bin/start"]

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec node --max_old_space_size=4096 index.js

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0-development",
   "main": "index.js",
   "scripts": {
-    "start": "node --max_old_space_size=4096 index.js",
+    "start": "./bin/start",
     "test": "node test/test | tap-dot",
     "lint": "jshint .",
     "travis": "npm run check-dependencies && npm test",


### PR DESCRIPTION
This script uses `exec` to ensure the PID of the script is the PID of the PIP service later.

The Dockerfile is updated to use the script, so that containers can be shut down immediately by avoiding any intermediate processes that won't forward signals.

See https://github.com/npm/npm/issues/4603
Fixes https://github.com/pelias/pip-service/issues/61