### PR TITLE
Add dependencies for building C++ Node modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pelias/baseimage
 
 # downloader apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y bzip2 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y autoconf automake libtool pkg-config python bzip2 && rm -rf /var/lib/apt/lists/*
 
 # change working dir
 ENV WORKDIR /code/pelias/pip-service


### PR DESCRIPTION
As of https://github.com/pelias/whosonfirst/pull/324, pelias/whosonfirst now includes [better-sqlite3](https://www.npmjs.com/package/better-sqlite3) which requires the [integer](https://www.npmjs.com/package/integer) library. `integer` is a C++ extension, so we need to add a toolchain including python to run `node-gyp` to compile this extension.