### PR TITLE
Use carat ranges for all Pelias Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "express": "^4.15.2",
     "lodash": "^4.17.4",
     "morgan": "^1.8.1",
-    "pelias-logger": "0.4.2",
-    "pelias-wof-admin-lookup": "4.6.5",
+    "pelias-logger": "^0.4.2",
+    "pelias-wof-admin-lookup": "^4.6.5",
     "through2": "^2.0.3"
   },
   "devDependencies": {
     "jshint": "^2.8.0",
-    "pelias-mock-logger": "1.3.0",
+    "pelias-mock-logger": "^1.3.0",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^2.0.0",
     "request": "^2.79.0",


### PR DESCRIPTION
The overhead of having to merge a Greenkeeper PR for every single change to
every single repository (which leads to cascading PRs) is too much.

Connects https://github.com/pelias/pelias/issues/366