### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM pelias/baseimage
 
 # downloader apt dependencies
 # note: this is done in one command in order to keep down the size of intermediate containers
-RUN apt-get update && apt-get install -y autoconf automake libtool pkg-config python bzip2 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y bzip2 && rm -rf /var/lib/apt/lists/*
 
 # change working dir
 ENV WORKDIR /code/pelias/pip-service

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,12 @@ RUN apt-get update && apt-get install -y bzip2 && rm -rf /var/lib/apt/lists/*
 ENV WORKDIR /code/pelias/pip-service
 WORKDIR ${WORKDIR}
 
+# copy package.json first to prevent npm install being rerun when only code changes
+COPY ./package.json ${WORKDIR}
+RUN npm install
+
 # copy code from local checkout
 ADD . ${WORKDIR}
-
-# install npm dependencies
-RUN npm install
 
 # run tests
 RUN npm test


### PR DESCRIPTION
This PR contains two small changes to increase the speed of repeated Docker build, and remove some dependency installation commands that were doing nothing since those packages are already in the pelias baseimage.