### PR TITLE
feat(download): add dedicated download binary

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+node node_modules/pelias-whosonfirst/utils/download_data.js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "jshint .",
     "travis": "npm test",
     "validate": "npm ls",
-    "download": "node node_modules/pelias-whosonfirst/utils/download_data.js"
+    "download": "./bin/download"
   },
   "author": "Mapzen",
   "license": "MIT",


### PR DESCRIPTION
This helps avoid usage of `npm run download`.

Connects https://github.com/pelias/pelias/issues/745