### PR TITLE
chore(package): update tape to version 4.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "proxyquire": "^2.0.0",
     "request": "^2.79.0",
     "tap-dot": "^2.0.0",
-    "tape": "^4.2.2",
+    "tape": "^4.10.1",
     "temp": "^0.9.0"
   },
   "pre-commit": [


### PR DESCRIPTION
Explicitly upgrading to 4.10.1 is required to avoid issues with top-level tests requiring a call to `end()` if there are nested tests.

See https://github.com/substack/tape/issues/459
Fixes https://github.com/pelias/pip-service/issues/102