### PR TITLE
fix(deps): Require wof-admin-lookup-5.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lodash": "^4.17.4",
     "morgan": "^1.8.1",
     "pelias-logger": "^1.2.1",
-    "pelias-wof-admin-lookup": "^5.0.0",
+    "pelias-wof-admin-lookup": "^5.1.2",
     "through2": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes a crash-causing bug and should be the minimum requirement

https://github.com/pelias/wof-admin-lookup/pull/255