### PR TITLE
chore(package.json): Remove npm engines configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
   "author": "Mapzen",
   "license": "MIT",
   "engines": {
-    "node": ">= 8.0.0",
-    "npm": "^3.10.10"
+    "node": ">= 8.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We don't really use this very consistently any more, and the NPM version
has grown out of date.

Ideally we will support whatever NPM version comes with the latest
version of each major version of Node.js