### PR TITLE
change downloader util from whosonfirst

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-node node_modules/pelias-whosonfirst/utils/download_data.js --admin-only
+node node_modules/pelias-whosonfirst/utils/download_sqlite_all.js --admin-only


### PR DESCRIPTION
Hey everybody,

   I was using pip-service in my k8s setup normally until today, when I had to re-deploy all Pelias stack and suddenly pip-service stopped working.
  The error was in the INIT container step (error bellow)
```
internal/modules/cjs/loader.js:796
    throw err;
    ^

Error: Cannot find module '/code/pelias/pip-service/node_modules/pelias-whosonfirst/utils/download_data.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:793:17)
    at Function.Module._load (internal/modules/cjs/loader.js:686:27)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1043:10)
    at internal/main/run_main_module.js:17:11 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```
After some debug, I realized that the pip-service docker image (tag: latest) was updated 14 days ago.
pip-service is now  using a new version of Pelias Who's on First Data Importer NPM package that doesn't have this downloader util anymore (/code/pelias/pip-service/node_modules/pelias-whosonfirst/utils/download_data.js).

Changing the download bash script to use download_sqlite_all.js solved the problem.