### PR TITLE
Add host address env var override and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,11 @@ The service supports the [DNT](https://en.wikipedia.org/wiki/Do_Not_Track) heade
 
 When any of these headers are supplied in the request (with any value), the request log will output `/[removed]/[removed]` instead of the longitude/latitude values.
 
-#### Configuration
+#### Configuration via Environment Variables
 
-The only available configuration option is the port on which the service runs.  To run on a different port, start with:
+The service supports additional environment variables that affect its operation:
 
-`PORT=3103 npm start`
+| Environment Variable | Default | Description |
+| -------------------- | ------- | ----------- |
+| `HOST` | `undefined` | The network address that the PiP service will bind to. Defaults to whatever the current Node.js default is, which is currently to listen on `0.0.0.0` (all interfaces). See the [Node.js Net documentation](https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback) for more information. |
+| `PORT` | `3102` | The TCP port that the PiP service will use for incoming network connections |

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
+const util = require('util');
 const app = require('./app')();
 
 try {
   const port = ( parseInt(process.env.PORT) || 3102 );
+  const host = process.env.HOST || undefined;
 
-  app.listen(port, () => {
-    console.log(`pip-service is now running on port ${port}`);
+  app.listen(port, host, () => {
+    console.log(util.format( 'pip-service is now running on %s:%s', host || '0.0.0.0', port ));
   });
 
 } catch (err) {


### PR DESCRIPTION
---
#### Here's the reason for this change :rocket:

* Added support for overriding the default network address to bind to via the `HOST` environment variable, in line with (almost) all of the other Pelias services.
---
#### Here's what actually got changed :clap:

* Update `index.js` adding support for the `HOST` env var and passing this to `app.listen()`
* Small update to `README.md` documenting this

---
#### Here's how others can test the changes :eyes:

Without `HOST` defined ...

```
PORT=4100 npm start
<snip>
2020-07-16T15:29:14.509Z - info: [placeholder] [worker 92474] listening on 0.0.0.0:4100
```

```
sudo lsof -i -P -n | grep LISTEN | grep 4100
node      92601          pelias   36u  IPv6 513692      0t0  TCP *:4100 (LISTEN)
```

With `HOST` defined ...

```
HOST=127.0.0.1 PORT=4100 npm start
<snip>
2020-07-16T15:31:23.397Z - info: [placeholder] [worker 92745] listening on 127.0.0.1:4100
```

```
$ sudo lsof -i -P -n | grep LISTEN | grep 4100
node      92737          pelias   36u  IPv4 501663      0t0  TCP 127.0.0.1:4100 (LISTEN)
```