### PR TITLE
Upgrade to wof-admin-lookup 7.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.17.4",
     "morgan": "^1.8.1",
     "pelias-logger": "^1.2.1",
-    "pelias-wof-admin-lookup": "^7.0.0",
+    "pelias-wof-admin-lookup": "^7.7.0",
     "through2": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This includes the changes in https://github.com/pelias/wof-admin-lookup/pull/311. While primarily meant to help the `boundary.country` API parameter with `dependency` placetypes, this change also affects the responses from coarse reverse geocoding queries.