### PR TITLE
Upgrade pelias-wof-admin-lookup to v7.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.17.4",
     "morgan": "^1.8.1",
     "pelias-logger": "^1.2.1",
-    "pelias-wof-admin-lookup": "^7.7.0",
+    "pelias-wof-admin-lookup": "^7.12.0",
     "through2": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Includes a fix for macroregions/region ordering from https://github.com/pelias/wof-admin-lookup/pull/325